### PR TITLE
Fix JSON payload in getUserIMStreamId function

### DIFF
--- a/lib/StreamsClient/index.js
+++ b/lib/StreamsClient/index.js
@@ -9,9 +9,7 @@ var StreamsClient = {}
 StreamsClient.getUserIMStreamId = (userIds) => {
   var defer = Q.defer()
 
-  var body = {
-    'userIds': userIds
-  }
+  var body = userIds
 
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,


### PR DESCRIPTION
Previous version incorrectly wrapped the array of integer user IDs in a JSON object, which was rejected by the underlying API.