### PR TITLE
Added Content-Type header in POST request for searchUsers function

### DIFF
--- a/lib/UsersClient/index.js
+++ b/lib/UsersClient/index.js
@@ -189,6 +189,7 @@ UsersClient.searchUsers = (query, local, skip, limit, filter) => {
     'path': '/pod/v1/user/search?local=' + (local ? 'true' : 'false') + '&skip=' + skip + '&limit=' + limit,
     'method': 'POST',
     'headers': {
+      'Content-Type': 'application/json',
       'sessionToken': SymBotAuth.sessionAuthToken
     },
     'agent': SymConfigLoader.SymConfig.proxy


### PR DESCRIPTION
Previous version omitted this header, meaning the payload could not be interpreted by the underlying API.